### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "github_actions"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,3 +8,4 @@ jobs:
       - uses: actions/checkout@v5
       - name: Validate with script
         run: ${GITHUB_WORKSPACE}/scripts/test.sh
+        


### PR DESCRIPTION
With only a single action in place this may seem like using a sledgehammer to crack a nut, but still I find this useful as a constant reminder, that there is an update available.
